### PR TITLE
The preprocessor wasn't doing token substitution nor token pasting on the macro name before calling a macro

### DIFF
--- a/mojoshader_preprocessor.c
+++ b/mojoshader_preprocessor.c
@@ -1265,6 +1265,9 @@ static int replace_and_push_macro(Context *ctx, const Define *def,
         return 0;
 
     IncludeState *state = ctx->include_stack;
+    const char* fname = state->filename;
+    const unsigned int line = state->line;
+
     IncludeState* stateOriginal = state;
     if (!push_source(ctx, state->filename, def->definition,
                      strlen(def->definition), state->line, NULL))
@@ -1274,6 +1277,7 @@ static int replace_and_push_macro(Context *ctx, const Define *def,
     } // if
 
     state = ctx->include_stack;
+
     while (lexer(state) != TOKEN_EOI)
     {
         int wantorig = 0;
@@ -1344,18 +1348,21 @@ static int replace_and_push_macro(Context *ctx, const Define *def,
             goto replace_and_push_macro_failed;
     } // while
 
+    pop_source(ctx); // ditch the macro.
+
     //if (const Define* def2 = find_define(ctx, def->definition))
     {
         //if (def2->paramcount > 0)
         {
             /**omg = def->definition;*/
             buffer_append(buffer, stateOriginal->source, strlen(stateOriginal->source));
-            // update_state(state, 1, state->source, s->source_base + s->orig_length, TOKEN_EOI);
-            stateOriginal->source = state->source_base + state->orig_length;
-            stateOriginal->token = state->source_base + state->orig_length;
-            stateOriginal->tokenval = TOKEN_EOI;
-            stateOriginal->tokenlen = 0;
-            stateOriginal->bytes_left = 0;
+            //// update_state(state, 1, state->source, s->source_base + s->orig_length, TOKEN_EOI);
+            //stateOriginal->source = state->source_base + state->orig_length;
+            //stateOriginal->token = state->source_base + state->orig_length;
+            //stateOriginal->tokenval = TOKEN_EOI;
+            //stateOriginal->tokenlen = 0;
+            //stateOriginal->bytes_left = 0;
+            pop_source(ctx);
         }
     }
 
@@ -1364,12 +1371,12 @@ static int replace_and_push_macro(Context *ctx, const Define *def,
         goto replace_and_push_macro_failed;
 
     buffer_destroy(buffer);
-    pop_source(ctx); // ditch the macro.
+
     state = ctx->include_stack;
 
 
     //if (!push_source(ctx, state->filename, (*omg).c_str(), (*omg).length(), state->line, close_define_include))
-    if (!push_source(ctx, state->filename, final, strlen(final), state->line, close_define_include))
+    if (!push_source(ctx, fname, final, strlen(final), line, close_define_include))
     {
         Free(ctx, final);
         return 0;

--- a/mojoshader_preprocessor.c
+++ b/mojoshader_preprocessor.c
@@ -10,8 +10,6 @@
 #define __MOJOSHADER_INTERNAL__ 1
 #include "mojoshader_internal.h"
 
-#include <string> // the C++ Standard String Class
-
 #if DEBUG_PREPROCESSOR
     #define print_debug_token(token, len, val) \
         MOJOSHADER_print_debug_token("PREPROCESSOR", token, len, val)
@@ -1325,7 +1323,6 @@ static int replace_and_push_macro(Context *ctx, const Define *def,
     const char* fname = state->filename;
     const unsigned int line = state->line;
 
-    IncludeState* stateOriginal = state;
     if (!push_source(ctx, state->filename, def->definition,
                      strlen(def->definition), state->line, NULL))
     {
@@ -1333,13 +1330,9 @@ static int replace_and_push_macro(Context *ctx, const Define *def,
         return 0;
     } // if
 
+    IncludeState* stateOriginal = state;
     state = ctx->include_stack;
 
-    std::string tmp;
-
-    bool firstIdentifier = true;
-    const char* firstIdent;
-    int fistIdentLength = 0;
     while (lexer(state) != TOKEN_EOI)
     {
         int wantorig = 0;
@@ -1393,13 +1386,6 @@ static int replace_and_push_macro(Context *ctx, const Define *def,
 
         if (state->tokenval == TOKEN_IDENTIFIER)
         {
-            if (firstIdentifier)
-            {
-                firstIdent = state->token;
-                fistIdentLength = state->tokenlen;
-                firstIdentifier = false;
-            }
-
             arg = find_macro_arg(state, params);
             if (arg != NULL)
             {
@@ -1703,9 +1689,7 @@ static int handle_pp_identifier(Context *ctx)
     buffer_destroy(out);
 
     const size_t deflen = strlen(def->definition);
-    //return push_source(ctx, fname, def->definition, deflen, line, NULL);
     return push_source(ctx, fname, final, finalLength, line, NULL);
-   // return push_source(ctx, fname, (*omg).data(), (*omg).length(), line, NULL);
 } // handle_pp_identifier
 
 

--- a/mojoshader_preprocessor.c
+++ b/mojoshader_preprocessor.c
@@ -1408,6 +1408,7 @@ static int replace_and_push_macro(Context *ctx, const Define *def,
     // flatten emptied buffer, we want to concatenate original contents, lets add it back
     buffer_append(buffer, finalizedMacro, strlen(finalizedMacro));
 
+    // Test if the expanded macro is also a macro and accepts params. If it does we need to add the params to the next IncludeState as well so they can be expanded with the macro
     // find end of the macro it is either separated by empty space or '(' character
     int macroEnd = findMacroEnd(finalizedMacro, strlen(finalizedMacro));
     if (macroEnd > 0)
@@ -1664,6 +1665,7 @@ static int handle_pp_identifier(Context *ctx)
     Buffer* out = buffer_create(128, MallocBridge, FreeBridge, ctx);
     buffer_append(out, def->definition, strlen(def->definition));
 
+    // Test if the expanded macro is also a macro and accepts params. If it does we need to add the params to the next IncludeState as well so they can be expanded with the macro
     // does the macro expension convert to another macro?
     if (const Define* def2 = find_define(ctx, def->definition))
     {

--- a/mojoshader_preprocessor.c
+++ b/mojoshader_preprocessor.c
@@ -1350,21 +1350,21 @@ static int replace_and_push_macro(Context *ctx, const Define *def,
 
     pop_source(ctx); // ditch the macro.
 
-    //if (const Define* def2 = find_define(ctx, def->definition))
-    {
-        //if (def2->paramcount > 0)
-        {
-            /**omg = def->definition;*/
-            buffer_append(buffer, stateOriginal->source, strlen(stateOriginal->source));
-            //// update_state(state, 1, state->source, s->source_base + s->orig_length, TOKEN_EOI);
-            //stateOriginal->source = state->source_base + state->orig_length;
-            //stateOriginal->token = state->source_base + state->orig_length;
-            //stateOriginal->tokenval = TOKEN_EOI;
-            //stateOriginal->tokenlen = 0;
-            //stateOriginal->bytes_left = 0;
-            pop_source(ctx);
-        }
-    }
+    ////if (const Define* def2 = find_define(ctx, def->definition))
+    //{
+    //    //if (def2->paramcount > 0)
+    //    {
+    //        /**omg = def->definition;*/
+    //        buffer_append(buffer, stateOriginal->source, strlen(stateOriginal->source));
+    //        //// update_state(state, 1, state->source, s->source_base + s->orig_length, TOKEN_EOI);
+    //        //stateOriginal->source = state->source_base + state->orig_length;
+    //        //stateOriginal->token = state->source_base + state->orig_length;
+    //        //stateOriginal->tokenval = TOKEN_EOI;
+    //        //stateOriginal->tokenlen = 0;
+    //        //stateOriginal->bytes_left = 0;
+    //        pop_source(ctx);
+    //    }
+    //}
 
     final = buffer_flatten(buffer);
     if (!final)
@@ -1562,6 +1562,38 @@ handle_macro_args_failed:
     return retval;
 } // handle_macro_args
 
+static int findClosingParenthesis(const char* str, int len)
+{
+    int i, count = 0, last_close = -1;
+    for (i = 0; i < len; i++)
+    {
+        if (str[i] == '(')
+        {
+            count++;
+            if (count == 1)
+            {
+                printf("First opening parenthesis found at position %d\n", i);
+            }
+        }
+        else if (str[i] == ')')
+        {
+            count--;
+            if (count == 0)
+            {
+                last_close = i;
+                printf("Matching closing parenthesis found at position %d\n", i);
+                return last_close;
+            }
+        }
+
+        if (count == 0 && last_close != -1)
+        {
+            break;
+        }
+    }
+
+    return -1;
+}
 
 static int handle_pp_identifier(Context *ctx)
 {
@@ -1598,9 +1630,18 @@ static int handle_pp_identifier(Context *ctx)
         {
             //*omg = def->definition;
             //*omg += state->source;
+            int closinParenthesis = findClosingParenthesis(state->source, strlen(state->source));
+            if (closinParenthesis)
+            {
+                buffer_append(out, state->source, closinParenthesis+1);
+            
+                   
+                state->bytes_left -= closinParenthesis + 1 ;
+                state->source = state->source + closinParenthesis + 1;
+                state->token = state->source;
 
-            buffer_append(out, state->source, strlen(state->source));
-            pop_source(ctx);
+            }
+            //pop_source(ctx);
             //// update_state(state, 1, state->source, s->source_base + s->orig_length, TOKEN_EOI);
             //state->source = state->source_base + state->orig_length;
             //state->token = state->source_base + state->orig_length;


### PR DESCRIPTION
Here are examples of what was not working:

Imagine setup like this

```
#define JOIN(x, y) JOIN2(x, y)
#define JOIN2(x, y) x ## y

#define CHANGE_NAME USE0

#define USE0(with, without) without
#define USE1(with, without) with

#define USE_IF_EXISTS(param, with, without) JOIN(USE, param)  ( with, without)

```

now you want to call something like this `USE_IF_EXISTS(SOME_PARAM, float3(0,0,0), SomeInterpolator)` 

That would not work because the the preprocessor cannot handle calling macro on the macro name. 

Another broken case is when the USE_IF_EXISTS is defined like this: 

```#define USE_IF_EXISTS(param, with, without) CHANGE_NAME( with, without)```

Just a regular non-function like macro also fails if used in a macro name. 


I've added code that checks whether  the expanded macro is also a macro and if it is then put function params onto the `IncludeState`. The function params were not added before and that is why it used to fail.

Basically the includeState is a stack that is created for everything that will have a variable length (it is not just a copy from source to the result). It takes a part of the string from the input source (which is another InludeState) and moves the cursor in the current state. The code was not including the macro function params into the IncludeState if the macro was in the name of the macro. 

For example in our simple case

```#define USE_IF_EXISTS(with, without) CHANGE_NAME( with, without)```

expanding code like this

```USE_IF_EXISTS(float3(1,2,3), float3(3,2,1)) ```

it will create a new state containing only
`CHANGE_NAME`

It will then try to process this state and it will correctly attempt to expand it into USE0. However there are no params so it will fail it will not translate it. Preprocessor output of this code will then look like this
```USE0(float3(1,2,3), float3(3,2,1))``` 
But the USE0 does not exists for the compiler so it fails to compile.

This code change attempts to correctly find if the expanded macro is also a macro and if it expects params and also if the params are in the code. If yes it will put the params after the macro name into the IncludeStack. 

It works pretty well.

Honestly ... I am not sure why mojo shader is using this IncludeStack system. It can break on bunch of levels (like the #ifs needs to be all handled in one IncludeStack). I think it is too complicated and could be solved easier, but maybe I am missing something. Anyway. I tried to implement this using their functions as correctly as I could.

Lastly this won't work for the case where there is more than one translation to the actual macro 
```
#THE_ACTUAL_MACRO(input) (dosomething(input))
#TRANSLATE2 THE_ACTUAL_MACRO
#TRANSLATE1 TRANSLATE2

TRANSLATE1(helloThisWillFail)
```

I can try to rewrite it to support this too, but I think we can live with it the way it is now